### PR TITLE
Load OpenVINO models with BaseOpenVINOBackend constructor

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,8 +13,6 @@ jobs:
       - image: aotuai/brainframe_build_env:0.26.0-openvino-2020
     resource_class: medium
     parallelism: 1
-    environment:
-      PYTHONPATH=$PYTHONPATH:/python_deps
     steps:
       # Add pull dependencies
       - run: mkdir -m 700 ~/.ssh/ &&
@@ -26,16 +24,13 @@ jobs:
       - checkout
       # Install test dependencies
       - restore_cache:
-          key: v1-python-cache--{{ checksum "tests/requirements.txt" }}
+          key: v2-python-cache--{{ checksum "tests/requirements.txt" }}
       - run: >
-          if ! pip3 show vcap > /dev/null; then
-            mkdir -p /python_deps
-            pip3 install --quiet -r tests/requirements.txt --target /python_deps
-          fi
+          pip3 install --quiet -r tests/requirements.txt --target /python_deps
       - save_cache:
-          key: v1-python-cache--{{ checksum "tests/requirements.txt" }}
+          key: v2-python-cache--{{ checksum "tests/requirements.txt" }}
           paths:
-            - /python_deps
+            - /root/.cache/pip
       # Run Capsule tests in multiple containers. Use circleci commands to split the test files up.
       - run: >
           circleci tests glob **/test*.py |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ workflows:
 jobs:
   run-tests:
     docker:
-      - image: aotuai/brainframe_build_env:0.26.0-openvino-2020
+      - image: aotuai/brainframe_build_env:0.26.0
     resource_class: medium
     parallelism: 1
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,6 +13,8 @@ jobs:
       - image: aotuai/brainframe_build_env:0.26.0-openvino-2020
     resource_class: medium
     parallelism: 1
+    environment:
+      PYTHONPATH=$PYTHONPATH:/python_deps
     steps:
       # Add pull dependencies
       - run: mkdir -m 700 ~/.ssh/ &&
@@ -27,14 +29,13 @@ jobs:
           key: v1-python-cache--{{ checksum "tests/requirements.txt" }}
       - run: >
           if ! pip3 show vcap > /dev/null; then
-            pip3 install --quiet -r tests/requirements.txt
+            mkdir -p /python_deps
+            pip3 install --quiet -r tests/requirements.txt --target /python_deps
           fi
       - save_cache:
           key: v1-python-cache--{{ checksum "tests/requirements.txt" }}
           paths:
-            - /usr/local/lib/python3.6/
-            - /usr/lib/python3.6/
-            - /usr/lib/python3/
+            - /python_deps
       # Run Capsule tests in multiple containers. Use circleci commands to split the test files up.
       - run: >
           circleci tests glob **/test*.py |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ workflows:
 jobs:
   run-tests:
     docker:
-      - image: aotuai/brainframe_build_env:0.26.0
+      - image: aotuai/brainframe_build_env:0.26.0-openvino-2020
     resource_class: medium
     parallelism: 1
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,7 +26,7 @@ jobs:
       - restore_cache:
           key: v2-python-cache--{{ checksum "tests/requirements.txt" }}
       - run: >
-          pip3 install --quiet -r tests/requirements.txt --target /python_deps
+          pip3 install --quiet -r tests/requirements.txt
       - save_cache:
           key: v2-python-cache--{{ checksum "tests/requirements.txt" }}
           paths:

--- a/capsules/classifier_vehicle_color_openvino/capsule.py
+++ b/capsules/classifier_vehicle_color_openvino/capsule.py
@@ -15,8 +15,8 @@ class Capsule(BaseCapsule):
         size=NodeDescription.Size.SINGLE,
         detections=config.vehicle_types,
         attributes={"color": config.colors})
-    backend_loader = lambda capsule_files, device: Backend.from_bytes(
-        model_bytes=capsule_files[
+    backend_loader = lambda capsule_files, device: Backend(
+        model_xml=capsule_files[
             "vehicle-attributes-recognition-barrier-0039.xml"],
-        weights_bytes=capsule_files[
+        weights_bin=capsule_files[
             "vehicle-attributes-recognition-barrier-0039.bin"])

--- a/capsules/detector_face_openvino/capsule.py
+++ b/capsules/detector_face_openvino/capsule.py
@@ -16,8 +16,8 @@ class Capsule(BaseCapsule):
     output_type = NodeDescription(
         size=NodeDescription.Size.ALL,
         detections=["face"])
-    backend_loader = lambda capsule_files, device: Backend.from_bytes(
-        model_bytes=capsule_files["face-detection-adas-0001.xml"],
-        weights_bytes=capsule_files["face-detection-adas-0001.bin"],
+    backend_loader = lambda capsule_files, device: Backend(
+        model_xml=capsule_files["face-detection-adas-0001.xml"],
+        weights_bin=capsule_files["face-detection-adas-0001.bin"],
     )
     options = common_detector_options

--- a/capsules/detector_pedestrian_overhead_openvino/capsule.py
+++ b/capsules/detector_pedestrian_overhead_openvino/capsule.py
@@ -17,8 +17,8 @@ class Capsule(BaseCapsule):
     output_type = NodeDescription(
         size=NodeDescription.Size.ALL,
         detections=["person"])
-    backend_loader = lambda capsule_files, device: Backend.from_bytes(
-        model_bytes=capsule_files["person-detection-retail-0013.xml"],
-        weights_bytes=capsule_files["person-detection-retail-0013.bin"],
+    backend_loader = lambda capsule_files, device: Backend(
+        model_xml=capsule_files["person-detection-retail-0013.xml"],
+        weights_bin=capsule_files["person-detection-retail-0013.bin"],
     )
     options = common_detector_options

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,4 +1,4 @@
-vcap==0.1.3
-vcap_utils==0.1.3
+vcap==0.1.4.dev4
+vcap_utils==0.1.4.dev4
 pytest~=5.0
 mock~=3.0


### PR DESCRIPTION
With the upgrade to OpenVINO 2020.2, we're now able to load models directly from memory. This removes the need for the `from_bytes` helper.