### PR TITLE
Bump the BrainFrame Build Env version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ workflows:
 jobs:
   run-tests:
     docker:
-      - image: aotuai/brainframe_build_env:0.28.0
+      - image: aotuai/brainframe_build_env:0.28.1
     resource_class: medium
     parallelism: 1
     steps:


### PR DESCRIPTION
This is so that we can test capsules against TensorFlow 2, and bumping the version is necessary to use a new-enough CUDA version.